### PR TITLE
fix: update build to export TinCan module correctly

### DIFF
--- a/build/tincan.js
+++ b/build/tincan.js
@@ -9709,10 +9709,10 @@ TinCan client library
  * @fileoverview Global |this| required for resolving indexes in node.
  * @suppress {globalThis}
  */
-if (typeof module !== "undefined" && module.exports) {
-  this["encoding-indexes"] =
-    require("./encoding-indexes.js")["encoding-indexes"];
-}
+// if (typeof module !== "undefined" && module.exports) {
+//   this["encoding-indexes"] =
+//     require("./encoding-indexes.js")["encoding-indexes"];
+// }
 
 (function(global) {
   'use strict';
@@ -12994,11 +12994,11 @@ if (typeof module !== "undefined" && module.exports) {
   if (!global['TextDecoder'])
     global['TextDecoder'] = TextDecoder;
 
-  if (typeof module !== "undefined" && module.exports) {
-    module.exports = {
-      TextEncoder: global['TextEncoder'],
-      TextDecoder: global['TextDecoder'],
-      EncodingIndexes: global["encoding-indexes"]
-    };
-  }
+//   if (typeof module !== "undefined" && module.exports) {
+//     module.exports = {
+//       TextEncoder: global['TextEncoder'],
+//       TextDecoder: global['TextDecoder'],
+//       EncodingIndexes: global["encoding-indexes"]
+//     };
+//   }
 }(this));


### PR DESCRIPTION

Tested in:

- [ ] Chrome xx
- [ ] FireFox xx
- [ ] Safari xx
- [ ] Brave xx
- [ ] IE Edge
- [ ] IE 11
- [ ] IE 10
- [ ] IE 9
- [ ] IE 8
- [ ] IE 7
- [ ] IE 6
